### PR TITLE
Refactor Transpose

### DIFF
--- a/runtime/ggma/src/Config.h
+++ b/runtime/ggma/src/Config.h
@@ -65,7 +65,7 @@ struct ModelConfig
 struct GGMAConfig
 {
   ModelConfig model; // Model architecture details
-  int cache_size = 32;
+  int max_total_tokens = 32;
   int ubatch = 32;
   KVCacheDataType kv_cache_type = KVCacheDataType::FLOAT32; // KV cache data type
 };

--- a/runtime/ggma/src/Context.cc
+++ b/runtime/ggma/src/Context.cc
@@ -78,7 +78,7 @@ uint64_t bufsize_for(const nnfw_tensorinfo *ti)
 ggma::Context::Context(const char *package_path) : _package_path(package_path)
 {
   _cfg = load_config(_package_path);
-  _cache.init(_cfg, _cfg.cache_size);
+  _cache.init(_cfg, _cfg.max_total_tokens);
 }
 
 ggma::GGMAConfig ggma::Context::load_config(const std::string &package_path)

--- a/runtime/ggma/src/Generate.cc
+++ b/runtime/ggma/src/Generate.cc
@@ -54,10 +54,8 @@ GGMA_STATUS Context::generate(ggma_token *tokens, size_t n_tokens, size_t n_toke
     _cache.set_pos(n_tokens);
 
     // 3. Transpose KV caches to the layout expected by the decoder.
-    _cache.transpose(true /* k */, "0213", _cfg.model.num_attention_heads, _cfg.cache_size,
-                     _cfg.model.hidden_size / _cfg.model.num_attention_heads);
-    _cache.transpose(false /* v */, "0213", _cfg.model.num_attention_heads, _cfg.cache_size,
-                     _cfg.model.hidden_size / _cfg.model.num_attention_heads);
+    _cache.transpose(true /* k */, "0213");
+    _cache.transpose(false /* v */, "0213");
 
     // 4. Unembed: obtain logits from the hidden state.
     unemb(hidden, n_tokens, logits); // logits = unemb(hidden)

--- a/runtime/ggma/src/KVCache.cc
+++ b/runtime/ggma/src/KVCache.cc
@@ -16,6 +16,7 @@
 
 #include "Config.h"
 #include "KVCache.h"
+#include "Transpose.h"
 
 #include <cstring>
 #include <stdexcept>
@@ -65,45 +66,35 @@ bool is_supported_type(KVCacheDataType type)
   }
 }
 
-void KVCache::transpose(bool is_k_cache, const char *perm, size_t seq_len, size_t num_heads,
-                        size_t head_dim)
+void KVCache::transpose(bool is_k_cache, const char *perm)
 {
-  if (perm == nullptr || strcmp(perm, "0213") != 0)
-    throw std::runtime_error("Only \"0213\" permutation is supported");
-
   std::vector<std::vector<uint8_t>> &cache_vector = is_k_cache ? k : v;
   const size_t element_bytes = element_size();
-  const size_t head_bytes = head_dim * element_bytes;
 
   for (size_t i = 0; i < cache_vector.size(); ++i)
   {
-    std::vector<uint8_t> transposed_cache = cache_vector[i];
-    uint8_t *input_data = cache_vector[i].data();
-    uint8_t *output_data = transposed_cache.data();
-
-    for (size_t s = 0; s < seq_len; ++s) // seq_len
-    {
-      for (size_t h = 0; h < num_heads; ++h) // num_heads
-      {
-        // source offset: s * (num_heads * head_bytes) + h * head_bytes
-        // target offset: h * (seq_len * head_bytes) + s * head_bytes
-        uint8_t *src_ptr = input_data + s * (num_heads * head_bytes) + h * head_bytes;
-        uint8_t *dst_ptr = output_data + h * (seq_len * head_bytes) + s * head_bytes;
-        memcpy(dst_ptr, src_ptr, head_bytes);
-      }
-    }
-
-    cache_vector[i] = std::move(transposed_cache);
+    transpose_4d(cache_vector[i].data(), perm, _shape, element_bytes);
   }
+
+  // Update _shape to reflect the permuted layout.
+  size_t old[4] = {_shape[0], _shape[1], _shape[2], _shape[3]};
+  for (int i = 0; i < 4; i++)
+    _shape[i] = old[perm[i] - '0'];
 }
 
-void KVCache::init(const ggma::GGMAConfig &cfg, int cache_size)
+void KVCache::init(const ggma::GGMAConfig &cfg, int max_total_tokens)
 {
   if (cfg.model.n_layers <= 0)
     throw std::runtime_error("n_layers not properly initialized");
 
   // Set KV cache data type from config
   data_type = cfg.kv_cache_type;
+
+  // Store the logical shape of each layer's buffer: [1, seq_len, num_heads, head_dim]
+  _shape[0] = 1;
+  _shape[1] = max_total_tokens;
+  _shape[2] = cfg.model.num_attention_heads;
+  _shape[3] = cfg.model.hidden_size / cfg.model.num_attention_heads;
 
   // Allocate space for K and V caches for each layer
   // Total: n_layers * 2 vectors (K and V for each layer)
@@ -112,7 +103,8 @@ void KVCache::init(const ggma::GGMAConfig &cfg, int cache_size)
 
   for (int i = 0; i < cfg.model.n_layers; ++i)
   {
-    size_t buffer_size = cfg.model.hidden_size * cache_size * element_size();
+    // buffer_size = prod(_shape) * element_size
+    size_t buffer_size = _shape[0] * _shape[1] * _shape[2] * _shape[3] * element_size();
     k[i].resize(buffer_size, 0);
     v[i].resize(buffer_size, 0);
   }

--- a/runtime/ggma/src/KVCache.h
+++ b/runtime/ggma/src/KVCache.h
@@ -45,7 +45,13 @@ struct KVCache
   KVCacheDataType data_type;           // Data type for KV cache
   std::vector<std::vector<uint8_t>> k; // Key caches for each layer (raw byte storage)
   std::vector<std::vector<uint8_t>> v; // Value caches for each layer (raw byte storage)
-  int64_t _pos = 0;                    // Current position in KV cache
+
+  // Logical shape of each layer's buffer: [1, seq_len, num_heads, head_dim]
+  // Updated after transpose() to reflect the permuted layout.
+  size_t _shape[4] = {0, 0, 0, 0};
+
+  // Current position in KV cache (number of tokens written so far)
+  int64_t _pos = 0;
 
   // Get element size in bytes based on data type
   size_t element_size() const
@@ -95,18 +101,17 @@ struct KVCache
   void advance_pos() { _pos++; }
 
   // Initialize KV cache
-  void init(const ggma::GGMAConfig &cfg, int cache_size);
+  void init(const ggma::GGMAConfig &cfg, int max_total_tokens);
 
   /**
    * @brief Transpose cache with "0213" permutation [0,2,1,3]
    * @param is_k_cache true for K cache, false for V cache
    * @param perm Permutation string (must be "0213")
-   * @param seq_len Sequence length dimension
-   * @param num_heads Number of attention heads
-   * @param head_dim Head dimension
+   *
+   * Uses the internally stored _shape to determine buffer dimensions.
+   * Updates _shape after transposition to reflect the new layout.
    */
-  void transpose(bool is_k_cache, const char *perm, size_t seq_len, size_t num_heads,
-                 size_t head_dim);
+  void transpose(bool is_k_cache, const char *perm);
 };
 
 // Utility functions for KVCacheDataType

--- a/runtime/ggma/src/Transpose.cc
+++ b/runtime/ggma/src/Transpose.cc
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Transpose.h"
+
+#include <cstring>
+#include <stdexcept>
+#include <vector>
+
+namespace ggma
+{
+
+void transpose_4d(uint8_t *data, const char *perm, const size_t dims[4], size_t element_bytes)
+{
+  if (perm == nullptr)
+    throw std::runtime_error("transpose_4d: perm must not be null");
+
+  if (strcmp(perm, "0213") != 0)
+    throw std::runtime_error("transpose_4d: only \"0213\" permutation is supported");
+
+  // "0213" swaps axis 1 and axis 2 while keeping axis 0 and axis 3 in place.
+  // dims = [d0, d1, d2, d3]  ->  output is [d0, d2, d1, d3]
+  const size_t d0 = dims[0];
+  const size_t d1 = dims[1];
+  const size_t d2 = dims[2];
+  const size_t d3 = dims[3];
+  // ggml-style byte strides for contiguous layout [d0, d1, d2, d3]
+  const size_t nb1 = d3 * element_bytes;
+  const size_t nb2 = d2 * nb1;
+  const size_t nb3 = d1 * nb2;
+
+  // Work on a temporary copy, then write back.
+  std::vector<uint8_t> tmp(data, data + d0 * d1 * d2 * d3 * element_bytes);
+
+  for (size_t a0 = 0; a0 < d0; ++a0)
+  {
+    for (size_t a1 = 0; a1 < d1; ++a1)
+    {
+      for (size_t a2 = 0; a2 < d2; ++a2)
+      {
+        // input [d0,d1,d2,d3]  ->  output [d0,d2,d1,d3]
+        const uint8_t *src = tmp.data() + a0 * nb3 + a1 * nb2 + a2 * nb1;
+        uint8_t *dst = data + a0 * nb3 + a2 * (d1 * nb1) + a1 * nb1;
+        memcpy(dst, src, nb1);
+      }
+    }
+  }
+}
+
+} // namespace ggma

--- a/runtime/ggma/src/Transpose.h
+++ b/runtime/ggma/src/Transpose.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 Samsung Electronics Co., Ltd. All Rights Reserved
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __GGMA_TRANSPOSE_H__
+#define __GGMA_TRANSPOSE_H__
+
+#include <cstddef>
+#include <cstdint>
+
+namespace ggma
+{
+
+/**
+ * @brief Apply a 4D axis permutation to a flat byte buffer in-place.
+ *
+ * @param data          Pointer to the raw tensor data (modified in-place)
+ * @param perm          Permutation string of length 4, e.g. "0213".
+ *                      perm[i] = j means output axis i reads from input axis j.
+ * @param dims          Array of 4 dimension sizes [d0, d1, d2, d3]
+ * @param element_bytes Size of one element in bytes (e.g. 4 for float32)
+ */
+void transpose_4d(uint8_t *data, const char *perm, const size_t dims[4], size_t element_bytes);
+
+} // namespace ggma
+
+#endif // __GGMA_TRANSPOSE_H__


### PR DESCRIPTION
Extract the KVCache transpose logic into a reusable function.

- Add transpose_4d() in Transpose.cc for in-place "0213" permutation.
- Store the logical shape (_shape[4]) inside KVCache so that transpose() can derive dimensions internally, simplifying the caller in Generate.cc.
- Update _shape after transposition using the perm string generically instead of hardcoding the "0213" case.
- Adopt ggml-style stride naming (nb1, nb2, nb3) for byte-level strides, consistent with the nb[i] convention in ggml.

ONE-DCO-1.0-Signed-off-by: Sanggyu Lee <sg5.lee@samsung.com>